### PR TITLE
Soundless parsing

### DIFF
--- a/read_lab.praat
+++ b/read_lab.praat
@@ -37,10 +37,10 @@ for stringNumber from 3 to numberOfStrings
     phone$ = Get string: 3
 
     @replace: time_start$
-    time_start  = number(replace.string$)
+    time_start  = replace.number
 
     @replace: time_end$
-    time_end  = number(replace.string$)
+    time_end  = replace.number
 
     time_mid = ((time_end-time_start)/2)+time_start
 
@@ -71,9 +71,5 @@ View & Edit
 
 #string replace to format time in seconds
 procedure replace: .string$
-    .string$ = replace_regex$ (.string$, "([0-9]{7})$", ".\1", 0)
-    .string$ = replace_regex$ (.string$, "0([1-9])\.", "\1.", 0)
-    .string$ = replace_regex$ (.string$, "0+\.", "0.", 0) 
-    .string$ = replace_regex$ (.string$, "0+$", "", 0)
+    .number = number(.string$) / 1e7
 endproc
-

--- a/read_lab.praat
+++ b/read_lab.praat
@@ -11,65 +11,51 @@
 #Allow Input
 form Info
     sentence Lab_file_dir /home/user_name/1.lab
-    sentence Sound_dir  /home/user_name/audio1.wav
 endform
 
 clearinfo
 
-#Open wav file
-soundID = Read from file: sound_dir$
-tgID = To TextGrid: "phone", ""
-
 #read the .lab file into praat
 
+tgID = undefined
 stringID = Read Strings from raw text file: lab_file_dir$
 numberOfStrings = Get number of strings
 
 for stringNumber from 3 to numberOfStrings
     selectObject: stringID
     line$ = Get string: stringNumber
-    stringID_parsed = Create Strings as tokens: line$
-    nStrings_parsed = Get number of strings
 
-    #Get info from each column
-    time_start$ = Get string: 1
-    time_end$ = Get string: 2
-    phone$ = Get string: 3
+    time_start = extractNumber(line$, "")
+    time_end   = extractNumber(line$, " ")
+    label$     = replace_regex$(line$, ".*\s(.*)$", "\1", 1)
 
-    @replace: time_start$
+    @replace: time_start
     time_start  = replace.number
 
-    @replace: time_end$
+    @replace: time_end
     time_end  = replace.number
 
-    time_mid = ((time_end-time_start)/2)+time_start
+    if tgID == undefined
+        tgID = Create TextGrid: 0, time_end, "token", ""
+        Rename: "Labels"
+    else
+        selectObject: tgID
+        duration = Get total duration
+        nocheck Extend time: time_end - duration, "End"
+    endif
 
-    left = index(phone$, "-")
-    left += 1
-    right = index(phone$, "+")
-    right = right - left
-    phone$ = mid$  (phone$, left, right)
-
-    removeObject: stringID_parsed
-
-    #4. write information in TextGrid format.
-    tmin = 0 ;
-    tmax = 1;
-
-    selectObject: tgID
- #Insert boundaries
+    #Insert boundaries
     nocheck Insert boundary: 1, time_start
     nocheck Insert boundary: 1, time_end
-    interval = Get interval at time: 1, time_mid
-    Set interval text: 1, interval, phone$
+    interval = Get low interval at time: 1, time_end
+    Set interval text: 1, interval, label$
 endfor
 
-removeObject: stringID 
-selectObject: soundID
-plusObject: tgID
-View & Edit
+removeObject: stringID
+selectObject: tgID
+Replace interval text: 1, 0, 0, "^.*?-([^+]*?)\+.*", "\1", "Regular Expressions"
 
 #string replace to format time in seconds
-procedure replace: .string$
-    .number = number(.string$) / 1e7
+procedure replace: .number
+    .number /= 1e7
 endproc


### PR DESCRIPTION
Currently, a `Sound` is required to get the total duration of the TextGrid. But if the main goal of the script is to parse HTK label files, these will not necessarily come with their audio files, so that requirement should be lifted.

The current implementation grows a TextGrid as it reads the lab file.

This could be improved if the parsing logic was transferred to a separate procedure, which could work on the selection of a single `Strings`, or a `Sound` + `Strngs` combination. That way, if a `Sound` is provided, the script could use it to generate a `TextGrid` with that duration, and if not, derive it from the content of the `Strings` object.