### PR TITLE
Clarified some information in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,35 @@
-# lab_to_praat
-A plugin for Praat to read information from an HTS .lab file, manipulate segmentations manually and save them back to a .lab file
+# plugin_htklabel
 
-Installation:
+A plugin for Praat to read information from a HTK / HTS label file and
+Master Label Files.
 
-first you must have the CPrAN client installed by following the documentation found here:
+## Installation:
 
-http://cpran.net/clients/cpran/#installation
+This plugin requires some of the existing plugins distributed through CPrAN.
+If you have the CPrAN client installed on your machine, you can install this
+plugin by typing
 
-Then you must run the setup.praat script found in the folder by running:
+    cpran install htklabel
 
-praat steup.pŕaat
+> NOTE: this will not work until registration on CPrAN is complete, which
+> should be soon.
+
+After that, you should be able to read `.lab` and `.mlf` files using the
+commands in the `Open` menu, and save TextGrid objects as labels using the
+commands in the `Save` menu.
+
+If **you do no not have the client** you can follow [these instructions][1] 
+to set it up and install the plugin as above.
+
+If **you cannot install the client**, you can still use this plugin, as long
+as you manually install all of its dependencies (and their dependencies).
+The full list of dependencies (pointing to their git repositories) is
+
+* [tap](https://gitlab.com/cpran/plugin_tap)
+* [utils](https://gitlab.com/cpran/plugin_utils)
+* [varargs](https://gitlab.com/cpran/plugin_varargs)
+* [printf](https://gitlab.com/cpran/plugin_printf)
+* [selection](https://gitlab.com/cpran/plugin_selection)
+* [strutils](https://gitlab.com/cpran/plugin_strutils)
+
+[1]: http://cpran.net/clients/cpran/#installation


### PR DESCRIPTION
The previous readme had some inaccuracies, which this corrects.

In particular, the client is not _required_, and the `setup.praat` script is called automatically by Praat when it starts up; it is not for users to run.

The name of the plugin was changed only to fit with the name that is currently in use throughout the plugin. This can be changed, but I personally think this name is good for a number of reasons.