### PR TITLE
Add context pruning script

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ TextGrid objects can be written to HTK / HTS labels using the
 `Save as HTK Label file...`. At this point, converting MLF Table objects to MLF
 files is not supported.
 
-Note that information that only information that can be stored in the selected
-TextGrid objects will be saved into the label file. This will _not_ include any
-coments that may have been there originally.
+Note that only information that can be stored in the selected TextGrid objects
+will be saved into the label file. This will _not_ include any coments that may
+have been there originally.

--- a/scripts/prune_context.praat
+++ b/scripts/prune_context.praat
@@ -1,0 +1,92 @@
+# This script is part of the htklabel CPrAN plugin for Praat.
+# The latest version is available through CPrAN or at
+# <http://cpran.net/plugins/htklabel>
+#
+# The htklabel plugin is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+#
+# The htklabel plugin is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with htklabel. If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright 2017 Christopher Shulby, Jose Joaquin Atria
+
+form Prune HTK label context...
+  integer Tier 0 (= all)
+  boolean Left_context no
+  boolean Name yes
+  boolean Right_context no
+endform
+
+if !(left + name + right)
+  exitScript: "Must select at least one label component"
+endif
+
+suffix$ = ""
+if left_context
+  suffix$ = suffix$ + "_left"
+endif
+if name
+  suffix$ = suffix$ + "_name"
+endif
+if right_context
+  suffix$ = suffix$ + "_right"
+endif
+
+total_textgrids = numberOfSelected("TextGrid")
+for i to total_textgrids
+  tg[i] = selected("TextGrid", i)
+endfor
+
+for i to total_textgrids
+  selectObject: tg[i]
+  new[i] = Copy: selected$("TextGrid") + suffix$
+
+  t  = if tier then tier else 1 fi
+  nt = if tier then tier else do("Get number of tiers") fi
+
+  for t to nt
+    item$ = if do("Is interval tier...", t) then "interval" else "point" fi
+
+    if !left_context
+      do("Replace " + item$ + " text...",
+        ... t, 0, 0, "^.*?-", "", "Regular Expressions")
+    endif
+
+    if !right_context
+      do("Replace " + item$ + " text...",
+        ... t, 0, 0, "\+.*$", "", "Regular Expressions")
+    endif
+
+    if !name
+      for j to do("Get number of " + item$ + "s...", t)
+        label$ = do$("Get label of " + item$ + "...", t, j)
+        if index(label$, "-")
+          if index(label$, "+")
+            new$ = replace_regex$(label$, "(.*?\-).*?(\+.*)", "\1\2", 1)
+          else
+            new$ = replace_regex$(label$, "(.*?\-).*", "\1", 1)
+          endif
+        elsif index(label$, "+")
+          new$ = replace_regex$(label$, ".*?(\+.*)", "\1", 1)
+        else
+          new$ = ""
+        endif
+
+        do("Set " + item$ + " text...", t, j, new$)
+      endfor
+    endif
+
+  endfor
+endfor
+
+selectObject()
+for i to total_textgrids
+  plusObject: new[i]
+endfor

--- a/setup.praat
+++ b/setup.praat
@@ -25,6 +25,7 @@ nocheck Add menu command:   "Objects",  "Open", "Read HTK Label file...", "", 0,
 nocheck Add menu command:   "Objects",  "Open", "Read HTK Master Label File...", "", 0, "scripts/read_mlf.praat"
 
 nocheck Add action command: "TextGrid", 0, "", 0, "", 0, "Save as HTK Label file...", "", 0, "scripts/write_lab.praat"
+nocheck Add action command: "TextGrid", 0, "", 0, "", 0, "Prune HTK context...", "Modify -", 1, "scripts/prune_context.praat"
 
 nocheck Add action command: "Table", 1, "", 0, "", 0, "MLF Table -", "", 0, ""
 nocheck Add action command: "Table", 1, "", 0, "", 0, "Query path from MLF Table...", "MLF Table -", 1, "scripts/query_mlf.praat"

--- a/t/context.t
+++ b/t/context.t
@@ -1,0 +1,45 @@
+include ../../plugin_tap/procedures/more.proc
+
+@no_plan()
+
+textgrid = Read from file: "../t/samples/context.TextGrid"
+
+# Left
+selectObject: textgrid
+runScript: "../scripts/prune_context.praat", 0, 1, 0, 0
+
+@is_true: numberOfSelected("TextGrid"), "Pruning selects TextGrid"
+@isnt: selected(), textgrid, "Pruning creates copy"
+
+@like: selected$("TextGrid"), "_left$", "Assign left suffix"
+@is$: do$("Get label of interval...", 1, 1), "",   "Empty left context"
+@is$: do$("Get label of interval...", 1, 3), "b-", "Extracted left context"
+
+Remove
+
+# Name
+selectObject: textgrid
+runScript: "../scripts/prune_context.praat", 0, 0, 1, 0
+
+@like: selected$("TextGrid"), "_name$", "Assign name suffix"
+@is$: do$("Get label of interval...", 1, 1), "a", "Extracted name from right"
+@is$: do$("Get label of interval...", 1, 2), "b", "Extracted name from both"
+@is$: do$("Get label of interval...", 1, 3), "c", "Extracted name from left"
+
+Remove
+
+# Right
+selectObject: textgrid
+runScript: "../scripts/prune_context.praat", 0, 0, 0, 1
+
+@like: selected$("TextGrid"), "_right$", "Assign right suffix"
+@is$: do$("Get label of interval...", 1, 3), "",   "Empty right context"
+@is$: do$("Get label of interval...", 1, 1), "+b", "Extracted right context"
+
+Remove
+
+removeObject: textgrid
+
+@ok_selection()
+
+@done_testing()

--- a/t/samples/context.TextGrid
+++ b/t/samples/context.TextGrid
@@ -1,0 +1,26 @@
+File type = "ooTextFile"
+Object class = "TextGrid"
+
+xmin = 0 
+xmax = 1.5 
+tiers? <exists> 
+size = 1 
+item []: 
+    item [1]:
+        class = "IntervalTier" 
+        name = "token" 
+        xmin = 0 
+        xmax = 1.5 
+        intervals: size = 3 
+        intervals [1]:
+            xmin = 0 
+            xmax = 0.5 
+            text = "a+b" 
+        intervals [2]:
+            xmin = 0.5 
+            xmax = 1 
+            text = "a-b+c" 
+        intervals [3]:
+            xmin = 1 
+            xmax = 1.5 
+            text = "b-c" 


### PR DESCRIPTION
As it turns out, [the HTK label spec _does_ mention context](http://www.ee.columbia.edu/ln/labrosa/doc/HTKBook21/node82.html):

> Actual label names can be any sequence of characters. However, the - and + characters are reserved for identifying the left and right context , respectively, in a context-dependent phone label. For example, the label N-aa+V might be used to denote the phone aa when preceded by a nasal and followed by a vowel. These context-dependency conventions are used in the label editor HLED, and are understood by all HTK tools. 

This patch adds a script to prune individual elements of the context labels. The current approach might need to be refactored in the future, but this should do for now.

The script (available through the GUI) allows the user to choose what elements to keep in the labels of the specified tiers: they can choose the left or right context, the label name, or any combination thereof.

The changes are done on a copy of the TextGrid, keeping the original as is.